### PR TITLE
Avoiding prototype/jQuery naming conflict.

### DIFF
--- a/yii-debug-toolbar/views/yii_debug_toolbar.php
+++ b/yii-debug-toolbar/views/yii_debug_toolbar.php
@@ -41,7 +41,9 @@
 </div>
 
 <script type="text/javascript">
-$(function() {
-    yiiDebugToolbar.init();
-});
+(function($) {
+	$(function(){
+		yiiDebugToolbar.init();
+	});
+}(jQuery));
 </script>


### PR DESCRIPTION
I wrapped the outer-most jQuery calls in a closure to prevent conflicts with other javascript libraries, e.g: prototype.
