### PR TITLE
Commit 7ce778 breaks toolbar

### DIFF
--- a/yii-debug-toolbar/assets/style.css
+++ b/yii-debug-toolbar/assets/style.css
@@ -292,3 +292,7 @@ margin-top:0.8em;
 {
     background: transparent url('bullet_toggle_minus.png') no-repeat scroll 100% 50%;
 }
+
+#yii-debug-toolbar .text-right {
+	text-align:right;
+}

--- a/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
+++ b/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
@@ -131,7 +131,7 @@ class YiiDebugToolbarPanelSql extends YiiDebugToolbarPanel
     }
 
     /**
-     * Returns the DB server info bu connection ID.
+     * Returns the DB server info by connection ID.
      * @param string $connectionId
      * @return mixed
      */
@@ -141,14 +141,23 @@ class YiiDebugToolbarPanelSql extends YiiDebugToolbarPanel
             && false !== ($connection instanceof CDbConnection)
             && '' !== ($serverInfo = $connection->getServerInfo()))
         {
-            $serverInfo = array(
-                'Driver' => $connection->getAttribute(PDO::ATTR_DRIVER_NAME),
-                'Server Version' => $connection->getServerVersion(),
+            $info = array(
+                'Driver' => $connection->getDriverName(),
+                'Server Version' => $connection->getServerVersion()
             );
-
-            $serverInfo['Uptime'] = $this->duration($serverInfo['Uptime']);
-
-            return $serverInfo;
+            
+            $lines = explode('  ', $serverInfo);
+            foreach($lines as $line) {
+                list($key, $value) = explode(': ', $line);
+                
+                $info[$key] = $value;
+            }
+            
+            if(!empty($info['Uptime'])) {
+                $info['Uptime'] = $this->duration($info['Uptime']);
+            }
+            
+            return $info;
         }
         return null;
     }

--- a/yii-debug-toolbar/views/panels/sql/callstack.php
+++ b/yii-debug-toolbar/views/panels/sql/callstack.php
@@ -9,6 +9,7 @@
 <table id="yii-debug-toolbar-sql-callstack" class="tabscontent">
     <thead>
         <tr>
+        	<th>ID</th>
             <th>Query</th>
             <th nowrap="nowrap">Time (s)</th>
         </tr>
@@ -16,6 +17,7 @@
     <tbody>
         <?php foreach($callstack as $id=>$entry): ?>
         <tr class="<?php echo ($id%2?'odd':'even') ?>">
+        	<td class="text-right"><?php echo $id; ?></td>
             <td width="100%"><?php echo CHtml::encode($entry[0]); ?></td>
             <td nowrap="nowrap"><?php echo sprintf('%0.6f',$entry[1]); ?></td>
         </tr>


### PR DESCRIPTION
7ce778 introduced some faulty code in the SQL server panel, the following should fix this and enhance the amount of information on the server info panel. 

I have found very little documentation for the output format of the `PDO::ATTR_SERVER_INFO`, so it's likely that this fix will break on non-mysql connections.
