### PR TITLE
PHP short open tags removed

### DIFF
--- a/yii-debug-toolbar/assets/ajax.php
+++ b/yii-debug-toolbar/assets/ajax.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 // change the following paths if necessary
 $yii=dirname(__FILE__).'/../../../yii-1.1.8.r3324/framework/yii.php';

--- a/yii-debug-toolbar/messages/ru/yii-debug-toolbar.php
+++ b/yii-debug-toolbar/messages/ru/yii-debug-toolbar.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 return array(
 	'TOOLBAR' => 'ТУЛБАР',

--- a/yii-debug-toolbar/messages/simple/yii-debug-toolbar.php
+++ b/yii-debug-toolbar/messages/simple/yii-debug-toolbar.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 return array(
 	'TOOLBAR' => '',

--- a/yii-debug-toolbar/panels/YiiDebugToolbarPanelAssets.php
+++ b/yii-debug-toolbar/panels/YiiDebugToolbarPanelAssets.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class YiiDebugToolbarPanelAssets extends YiiDebugToolbarPanel{
     function getMenuTitle(){ return YiiDebug::t('Assets'); }

--- a/yii-debug-toolbar/panels/YiiDebugToolbarPanelExample.php
+++ b/yii-debug-toolbar/panels/YiiDebugToolbarPanelExample.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class YiiDebugToolbarPanelExample extends YiiDebugToolbarPanel{
     function getMenuTitle(){ return YiiDebug::t('Blank'); }

--- a/yii-debug-toolbar/views/panels/asset.php
+++ b/yii-debug-toolbar/views/panels/asset.php
@@ -1,38 +1,38 @@
 <table>
     <thead>
         <tr>
-            <th class="al-r"><?=YiiDebug::t('Properties')?></th>
+            <th class="al-r"><?php echo YiiDebug::t('Properties')?></th>
             <th></th>
         </tr>
     </thead>
     <tbody>
         <tr class="even">
-            <th><?=YiiDebug::t('Assets path')?></th>
-            <td><?=$AM->getBasePath()?></td>
+            <th><?php echo YiiDebug::t('Assets path')?></th>
+            <td><?php echo $AM->getBasePath()?></td>
         </tr><tr class="odd">
-            <th><?=YiiDebug::t('Exclude files')?></th>
-            <td><?=implode(',', $AM->excludeFiles)?></td>
+            <th><?php echo YiiDebug::t('Exclude files')?></th>
+            <td><?php echo implode(',', $AM->excludeFiles)?></td>
         </tr><tr class="even">
-            <th><?=YiiDebug::t('New dir mode')?></th>
-            <td><?=$AM->newDirMode?></td>
+            <th><?php echo YiiDebug::t('New dir mode')?></th>
+            <td><?php echo $AM->newDirMode?></td>
         </tr><tr class="odd">
-            <th><?=YiiDebug::t('New file mode')?></th>
-            <td><?=$AM->newFileMode?></td>
+            <th><?php echo YiiDebug::t('New file mode')?></th>
+            <td><?php echo $AM->newFileMode?></td>
         </tr>
     </tbody>
 </table>
 <table>
     <thead>
         <tr>
-            <th class="al-r"><?=YiiDebug::t('Load assets')?></th>
-            <th class="al-l"><?=YiiDebug::t('Path')?></th>
-            <th><?=YiiDebug::t('Files')?></th>
-            <th><?=YiiDebug::t('Date create')?></th>
+            <th class="al-r"><?php echo YiiDebug::t('Load assets')?></th>
+            <th class="al-l"><?php echo YiiDebug::t('Path')?></th>
+            <th><?php echo YiiDebug::t('Files')?></th>
+            <th><?php echo YiiDebug::t('Date create')?></th>
             <th></th>
         </tr>
     </thead>
     <tbody>
-        <?
+        <?php
         
         $DF = new CDateFormatter(Yii::app()->sourceLanguage);
         $i=0;
@@ -47,24 +47,24 @@
 			if(preg_match('|yii\.debug\.toolbar\.js|is', $fileList)) $blockAll = true;
 
             ?>
-        <tr class="<?=$i%2?'even':'odd'?>">
-            <th><?=$asset?></th>
+        <tr class="<?php echo $i%2?'even':'odd'?>">
+            <th><?php echo $asset?></th>
             <td>
-                <a title="<?=YiiDebug::t('Show files')?>" href="#"
-				   onclick="jQuery('.details', $(this).parent('td')).toggleClass('hidden'); return false;"><?=$path?></a>
+                <a title="<?php echo YiiDebug::t('Show files')?>" href="#"
+				   onclick="jQuery('.details', $(this).parent('td')).toggleClass('hidden'); return false;"><?php echo $path?></a>
                 <div class='details hidden'>
-                    <?=$fileList?>
+                    <?php echo $fileList?>
                 </div>
             </td>
-            <td class="al-c"><?=YiiDebug::t('{n} file|{n} files', array(count($files)))?></td>
-            <td class="al-c"><?=$DF->formatDateTime(filemtime($path))?></td>
+            <td class="al-c"><?php echo YiiDebug::t('{n} file|{n} files', array(count($files)))?></td>
+            <td class="al-c"><?php echo $DF->formatDateTime(filemtime($path))?></td>
             <td class="al-c">
-                <a class="deleteAsset" href="<?=$this->owner->assetsUrl?>/ajax.php?deleteasset=<?=$asset?>"
-						onclick="deleteAsset(this, <?=$blockAll?'true':'false'?>); return false;">
-										<?=YiiDebug::t('Clean')?></a>
+                <a class="deleteAsset" href="<?php echo $this->owner->assetsUrl?>/ajax.php?deleteasset=<?php echo $asset?>"
+						onclick="deleteAsset(this, <?php echo $blockAll?'true':'false'?>); return false;">
+										<?php echo YiiDebug::t('Clean')?></a>
             </td>
         </tr>
-        <?}?>
+        <?php } ?>
     </tbody>
 </table>
 
@@ -78,10 +78,10 @@
 				}
 			}
 			if(data == 'notexists'){
-				alert('<?=YiiDebug::t('Path not found.')?>');
+				alert('<?php echo YiiDebug::t('Path not found.')?>');
 			}
 			if(data == 'unknow'){
-				alert('<?=YiiDebug::t('Unknow error.')?>');
+				alert('<?php echo YiiDebug::t('Unknow error.')?>');
 			}
 		});
 	}

--- a/yii-debug-toolbar/views/panels/globals.php
+++ b/yii-debug-toolbar/views/panels/globals.php
@@ -1,11 +1,11 @@
 <div class="col left">
 
-    <h4 class="collapsible">SERVER <?=YiiDebug::t('Variables')?></h4>
+    <h4 class="collapsible">SERVER <?php echo YiiDebug::t('Variables')?></h4>
     <table id="debug-toolbar-globals-server">
         <thead>
             <tr>
-                <th><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -19,12 +19,12 @@
     </table>
 
     <?php if ($cookies) : $c=0;?>
-    <h4 class="collapsible">COOKIES <?=YiiDebug::t('Variables')?></h4>
+    <h4 class="collapsible">COOKIES <?php echo YiiDebug::t('Variables')?></h4>
     <table id="debug-toolbar-globals-cookies">
         <thead>
             <tr>
-                <th><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -38,17 +38,17 @@
     </table>
     <?php else : ?>
     <h4>COOKIES Variables</h4>
-    <?=YiiDebug::t('No COOKIE data')?>
+    <?php echo YiiDebug::t('No COOKIE data')?>
     <?php endif; ?>
 
 
     <?php if ($session) : $c=0; ?>
-    <h4 class="collapsible">SESSION <?=YiiDebug::t('Variables')?></h4>
+    <h4 class="collapsible">SESSION <?php echo YiiDebug::t('Variables')?></h4>
     <table id="debug-toolbar-globals-session">
         <thead>
             <tr>
-                <th><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -62,7 +62,7 @@
     </table>
     <?php else : ?>
     <h4>SESSION Variables</h4>
-    <?=YiiDebug::t('No SESSION data')?>
+    <?php echo YiiDebug::t('No SESSION data')?>
     <?php endif; ?>
 
 </div>
@@ -70,12 +70,12 @@
 <div class="col right">
 
     <?php if ($get) : $c=0; ?>
-    <h4 class="collapsible">GET <?=YiiDebug::t('Variables')?></h4>
+    <h4 class="collapsible">GET <?php echo YiiDebug::t('Variables')?></h4>
     <table id="debug-toolbar-globals-get">
         <thead>
             <tr>
-                <th><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -89,16 +89,16 @@
     </table>
     <?php else : ?>
     <h4>GET Variables</h4>
-    <?=YiiDebug::t('No GET data')?>
+    <?php echo YiiDebug::t('No GET data')?>
     <?php endif; ?>
 
     <?php if ($post) : $c=0; ?>
-    <h4 class="collapsible">POST <?=YiiDebug::t('Variables')?></h4>
+    <h4 class="collapsible">POST <?php echo YiiDebug::t('Variables')?></h4>
     <table id="debug-toolbar-globals-post">
         <thead>
             <tr>
-                <th><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -112,7 +112,7 @@
     </table>
     <?php else : ?>
     <h4>POST Variables</h4>
-    <?=YiiDebug::t('No POST data')?>
+    <?php echo YiiDebug::t('No POST data')?>
     <?php endif; ?>
 
 
@@ -121,8 +121,8 @@
     <table id="debug-toolbar-globals-files">
         <thead>
             <tr>
-                <th><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -136,7 +136,7 @@
     </table>
     <?php else : ?>
     <h4>FILES</h4>
-    <?=YiiDebug::t('No FILES data')?>
+    <?php echo YiiDebug::t('No FILES data')?>
     <?php endif; ?>
 
 </div>

--- a/yii-debug-toolbar/views/panels/logging.php
+++ b/yii-debug-toolbar/views/panels/logging.php
@@ -10,10 +10,10 @@ $colors=array(
     <thead>
         <tr>
             <th class="collapsible collapsed al-l" rel="#yii-debug-toolbar-log .details">
-				<?=YiiDebug::t('Message (details)')?></th>
-            <th nowrap="nowrap"><?=YiiDebug::t('Level')?></th>
-            <th nowrap="nowrap" class="al-l"><?=YiiDebug::t('Category')?></th>
-            <th nowrap="nowrap"><?=YiiDebug::t('Time')?></th>
+				<?php echo YiiDebug::t('Message (details)')?></th>
+            <th nowrap="nowrap"><?php echo YiiDebug::t('Level')?></th>
+            <th nowrap="nowrap" class="al-l"><?php echo YiiDebug::t('Category')?></th>
+            <th nowrap="nowrap"><?php echo YiiDebug::t('Time')?></th>
         </tr>
     </thead>
     <tbody>

--- a/yii-debug-toolbar/views/panels/settings.php
+++ b/yii-debug-toolbar/views/panels/settings.php
@@ -1,11 +1,11 @@
 <div class="col left">
     
-    <h4 class="collapsible"><?=YiiDebug::t('Application Properties')?></h4>
+    <h4 class="collapsible"><?php echo YiiDebug::t('Application Properties')?></h4>
     <table>
         <thead>
             <tr>
-                <th width="180"><?=YiiDebug::t('Property')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th width="180"><?php echo YiiDebug::t('Property')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -18,12 +18,12 @@
         </tbody>
     </table>
 
-    <h4 class="collapsible"><?=YiiDebug::t('Modules')?></h4>
+    <h4 class="collapsible"><?php echo YiiDebug::t('Modules')?></h4>
     <table>
         <thead>
             <tr>
-                <th width="180"><?=YiiDebug::t('Module ID')?></th>
-                <th><?=YiiDebug::t('Configuration')?></th>
+                <th width="180"><?php echo YiiDebug::t('Module ID')?></th>
+                <th><?php echo YiiDebug::t('Configuration')?></th>
             </tr>
         </thead>
         <tbody>
@@ -36,12 +36,12 @@
         </tbody>
     </table>
 
-    <h4 class="collapsible"><?=YiiDebug::t('Application Params')?></h4>
+    <h4 class="collapsible"><?php echo YiiDebug::t('Application Params')?></h4>
     <table>
         <thead>
             <tr>
-                <th width="180"><?=YiiDebug::t('Name')?></th>
-                <th><?=YiiDebug::t('Value')?></th>
+                <th width="180"><?php echo YiiDebug::t('Name')?></th>
+                <th><?php echo YiiDebug::t('Value')?></th>
             </tr>
         </thead>
         <tbody>
@@ -58,12 +58,12 @@
 
 <div class="col right">
 
-    <h4 class="collapsible"><?=YiiDebug::t('Components')?></h4>
+    <h4 class="collapsible"><?php echo YiiDebug::t('Components')?></h4>
     <table>
         <thead>
             <tr>
-                <th width="180"><?=YiiDebug::t('Component ID')?></th>
-                <th><?=YiiDebug::t('Configuration')?></th>
+                <th width="180"><?php echo YiiDebug::t('Component ID')?></th>
+                <th><?php echo YiiDebug::t('Configuration')?></th>
             </tr>
         </thead>
         <tbody>

--- a/yii-debug-toolbar/views/panels/sql.php
+++ b/yii-debug-toolbar/views/panels/sql.php
@@ -1,10 +1,10 @@
 <ul class="yii-debug-toolbar-tabs">
     <li class="active" type="yii-debug-toolbar-sql-summary"><a href="javascript:;//">
-		<?=Yii::t('yii-debug-toolbar','Summary')?></a></li>
+		<?php echo Yii::t('yii-debug-toolbar','Summary')?></a></li>
     <li type="yii-debug-toolbar-sql-callstack"><a href="javascript:;//">
-		<?=Yii::t('yii-debug-toolbar','Callstack')?></a></li>
+		<?php echo Yii::t('yii-debug-toolbar','Callstack')?></a></li>
     <li type="yii-debug-toolbar-sql-servers"><a href="javascript:;//">
-		<?=Yii::t('yii-debug-toolbar','Servers')?></a></li>
+		<?php echo Yii::t('yii-debug-toolbar','Servers')?></a></li>
 </ul>
 
 <?php $this->render('sql/servers', array(

--- a/yii-debug-toolbar/views/panels/sql/callstack.php
+++ b/yii-debug-toolbar/views/panels/sql/callstack.php
@@ -2,9 +2,9 @@
 <table id="yii-debug-toolbar-sql-callstack" class="tabscontent">
     <thead>
         <tr>
-        	<th><?=Yii::t('yii-debug-toolbar','ID')?></th>
-            <th><?=Yii::t('yii-debug-toolbar','Query')?></th>
-            <th nowrap="nowrap"><?=Yii::t('yii-debug-toolbar','Time (s)')?></th>
+        	<th><?php echo Yii::t('yii-debug-toolbar','ID')?></th>
+            <th><?php echo Yii::t('yii-debug-toolbar','Query')?></th>
+            <th nowrap="nowrap"><?php echo Yii::t('yii-debug-toolbar','Time (s)')?></th>
         </tr>
     </thead>
     <tbody>
@@ -19,6 +19,6 @@
 </table>
 <?php else : ?>
 <p id="yii-debug-toolbar-sql-callstack" class="tabscontent">
-    <?=Yii::t('yii-debug-toolbar','No SQL queries were recorded during this request or profiling the SQL is DISABLED.')?>
+    <?php echo Yii::t('yii-debug-toolbar','No SQL queries were recorded during this request or profiling the SQL is DISABLED.')?>
 </p>
 <?php endif; ?>

--- a/yii-debug-toolbar/views/panels/sql/servers.php
+++ b/yii-debug-toolbar/views/panels/sql/servers.php
@@ -1,6 +1,6 @@
 <div id="yii-debug-toolbar-sql-servers" class="tabscontent">
 <?php if ($connections) : foreach($connections as $id=>$connection): ?>
-<h4><?=Yii::t('yii-debug-toolbar','Connection ID')?>: <?php echo $id ?> (<?php echo get_class($connection)?>)</h4>
+<h4><?php echo Yii::t('yii-debug-toolbar','Connection ID')?>: <?php echo $id ?> (<?php echo get_class($connection)?>)</h4>
 <?php $serverInfo = $this->getServerInfo($id); $c=1;?>
     <table>
         <tbody>

--- a/yii-debug-toolbar/views/panels/sql/summary.php
+++ b/yii-debug-toolbar/views/panels/sql/summary.php
@@ -2,12 +2,12 @@
 <table id="yii-debug-toolbar-sql-summary" class="tabscontent">
     <thead>
         <tr>
-            <th><?=Yii::t('yii-debug-toolbar','Query')?></th>
-            <th nowrap="nowrap"><?=Yii::t('yii-debug-toolbar','Count')?></th>
-            <th nowrap="nowrap"><?=Yii::t('yii-debug-toolbar','Total (s)')?></th>
-            <th nowrap="nowrap"><?=Yii::t('yii-debug-toolbar','Avg. (s)')?></th>
-            <th nowrap="nowrap"><?=Yii::t('yii-debug-toolbar','Min. (s)')?></th>
-            <th nowrap="nowrap"><?=Yii::t('yii-debug-toolbar','Max. (s)')?></th>
+            <th><?php echo Yii::t('yii-debug-toolbar','Query')?></th>
+            <th nowrap="nowrap"><?php echo Yii::t('yii-debug-toolbar','Count')?></th>
+            <th nowrap="nowrap"><?php echo Yii::t('yii-debug-toolbar','Total (s)')?></th>
+            <th nowrap="nowrap"><?php echo Yii::t('yii-debug-toolbar','Avg. (s)')?></th>
+            <th nowrap="nowrap"><?php echo Yii::t('yii-debug-toolbar','Min. (s)')?></th>
+            <th nowrap="nowrap"><?php echo Yii::t('yii-debug-toolbar','Max. (s)')?></th>
         </tr>
     </thead>
     <tbody>
@@ -25,6 +25,6 @@
 </table>
 <?php else : ?>
 <p id="yii-debug-toolbar-sql-summary" class="tabscontent">
-    <?=Yii::t('yii-debug-toolbar','No SQL queries were recorded during this request or profiling the SQL is DISABLED.')?>
+    <?php echo Yii::t('yii-debug-toolbar','No SQL queries were recorded during this request or profiling the SQL is DISABLED.')?>
 </p>
 <?php endif; ?>

--- a/yii-debug-toolbar/views/yii_debug_toolbar.php
+++ b/yii-debug-toolbar/views/yii_debug_toolbar.php
@@ -1,9 +1,9 @@
-<?
+<?php
 $allPanelID = array();
 ?>
 
 <div id="yii-debug-toolbar-swither">
-    <a href="javascript:;//"><?=YiiDebug::t('TOOLBAR')?></a>
+    <a href="javascript:;//"><?php echo YiiDebug::t('TOOLBAR')?></a>
 </div>
 <div id="yii-debug-toolbar" style="display:none;">
     <div id="yii-debug-toolbar-buttons">
@@ -28,7 +28,7 @@ $allPanelID = array();
     <?php foreach ($panels as $panel) : ?>
     <div id="<?php echo $panel->id ?>" class="yii-debug-toolbar-panel">
         <div class="yii-debug-toolbar-panel-title">
-        <a href="#close" class="yii-debug-toolbar-panel-close"><?=YiiDebug::t('Close')?></a>
+        <a href="#close" class="yii-debug-toolbar-panel-close"><?php echo YiiDebug::t('Close')?></a>
         <h3>
             <?php echo CHtml::encode($panel->title); ?>
             <?php if ($panel->subTitle) : ?>
@@ -50,19 +50,19 @@ $allPanelID = array();
 
 <script type="text/javascript">
 
-    var $allPanelID = <?=json_encode($allPanelID)?>;
+    var $allPanelID = <?php echo json_encode($allPanelID); ?>;
     var hash = '';
 
 (function($) {
     $(function(){
         yiiDebugToolbar.init();
 
-        <?if($this->owner->openLastPanel){?>
+        <?php if($this->owner->openLastPanel){ ?>
         hash = location.hash.replace('#','');
         if($allPanelID.indexOf(hash) != -1){
             $('#yii-debug-toolbar-tab-'+hash).trigger('click');
         }
-        <?}?>
+        <?php } ?>
     });
 }(jQuery));
 </script>


### PR DESCRIPTION
Hey,

I couldn't run this debug toolbar on a system with "short_open_tag" set to false. So I expanded all short tags (and echo shortcuts) to their long versions.

Feel free to merge if you wish.
