### PR TITLE
Fixed a bug. SQLite doesn't support getServerInfo

### DIFF
--- a/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
+++ b/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
@@ -145,6 +145,7 @@ class YiiDebugToolbarPanelSql extends YiiDebugToolbarPanel
     {
         if (null !== ($connection = Yii::app()->getComponent($connectionId))
             && false !== ($connection instanceof CDbConnection)
+			&& 'sqlite' !== $connection->driverName
             && '' !== ($serverInfo = $connection->getServerInfo()))
         {
             $info = array(

--- a/yii-debug-toolbar/views/panels/sql/servers.php
+++ b/yii-debug-toolbar/views/panels/sql/servers.php
@@ -4,12 +4,18 @@
 <?php $serverInfo = $this->getServerInfo($id); $c=1;?>
     <table>
         <tbody>
+		<?php if(is_array($serverInfo)): ?>
             <?php foreach($serverInfo as $param=>$value){ ++$c;?>
             <tr class="<?php echo ($c%2?'odd':'even') ?>">
                 <th><?php echo CHtml::encode($param)?></th>
                 <td><?php echo CHtml::encode($value)?></td>
             </tr>
             <?php } ?>
+		<?php else: ?>
+			<tr class="<?php echo ($c%2?'odd':'even') ?>">
+                <th>SQLite doesn't support this info.</th>
+            </tr>
+		<?php endif; ?>
         </tbody>
     </table>
     <?php //YiiDebug::dump($info); ?>


### PR DESCRIPTION
I noticed a bug when the application uses SQLite, the debug toolbar wasn't working. After some digging in the code I saw there is a getServerInfo call which isn't supported by SQLite. So I added an if statement to that bit.
