### PR TITLE
Problem when running the toolbar throws a string-code Exception

### DIFF
--- a/yii-debug-toolbar/YiiDebugToolbar.php
+++ b/yii-debug-toolbar/YiiDebugToolbar.php
@@ -135,16 +135,10 @@ class YiiDebugToolbar extends CWidget
     {
         $content = '';
 
-        try {
-            $content .= $this->render('yii_debug_toolbar', array(
-                'panels' => $this->getPanels()
-            ), true);
-        }
-        catch (Exception $e)
-        {
-            throw new CException($e->getMessage(), $e->getCode(), $e->getPrevious());
-        }
-
+        $content .= $this->render('yii_debug_toolbar', array(
+            'panels' => $this->getPanels()
+        ), true);
+        
         echo $content;
     }
 


### PR DESCRIPTION
In my dev machine my database was causing a PDOException - that has a string code, instead of integer code as CException has.
After that, digging in the code, I've found that YiiDebugToolbar::run() was catching all exceptions and re-throwing them as CExceptions... and that caused a fatal error, since the code type mismatches.
As catching an exception just for throwing it again looks, for me, useless, I removed that part of code and let the exception happen naturally.
