### PR TITLE
OCI doesn't support PDO::getAttribute

### DIFF
--- a/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
+++ b/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
@@ -200,7 +200,7 @@ class YiiDebugToolbarPanelSql extends YiiDebugToolbarPanel
     {
         if (null !== ($connection = Yii::app()->getComponent($connectionId))
             && false !== ($connection instanceof CDbConnection)
-            && 'sqlite' !== $connection->driverName
+            && !in_array($connection->driverName, array('sqlite', 'oci'))
             && '' !== ($serverInfo = $connection->getServerInfo()))
         {
             $info = array(


### PR DESCRIPTION
Using PDO_OCI with YiiDebugToolbar caused an exception, as it doesn't support PDO::getAttribute.
The solution was to blacklist it along with SQLite (that was already there).
