### PR TITLE
Exception

### DIFF
--- a/yii-debug-toolbar/widgets/YiiDebugToolbarResourceUsage.php
+++ b/yii-debug-toolbar/widgets/YiiDebugToolbarResourceUsage.php
@@ -50,7 +50,11 @@ class YiiDebugToolbarResourceUsage extends CWidget
 
         if (function_exists('mb_strlen') && isset($_SESSION))
         {
-            $resources[YiiDebug::t('Session Size')] = sprintf('%0.3F KB' ,mb_strlen(serialize($_SESSION))/1024);
+            try {
+                $resources[YiiDebug::t('Session Size')] = sprintf('%0.3F KB' ,mb_strlen(serialize($_SESSION))/1024);
+            } catch (Exception $e) {
+                $resources[YiiDebug::t('Session Size')] = 'Unknown';
+            }
         }
 
 


### PR DESCRIPTION
If in session stored some elements, such as `SimpleXMLElement`, then their serialization throws an exception
