### PR TITLE
Pull request for issue #49

### DIFF
--- a/yii-debug-toolbar/YiiDebugToolbar.php
+++ b/yii-debug-toolbar/YiiDebugToolbar.php
@@ -157,17 +157,19 @@ class YiiDebugToolbar extends CWidget
         {
             if (!is_object($config))
             {
-                isset($config['class']) || $config['class'] = $id;
-                if (isset($config['enabled']) && false === $config['enabled'])
+                if(is_array($config))
                 {
-                    unset($this->_panels[$id]);
-                    continue;
+                    isset($config['class']) || $config['class'] = $id;
+                    if (isset($config['enabled']) && false === $config['enabled'])
+                    {
+                        unset($this->_panels[$id]);
+                        continue;
+                    }
+                    else if (isset($config['enabled']) && true === $config['enabled'])
+                    {
+                        unset($config['enabled']);
+                    }
                 }
-                else if (isset($config['enabled']) && true === $config['enabled'])
-                {
-                    unset($config['enabled']);
-                }
-
                 $panel = Yii::createComponent($config, $this);
 
                 if (false === ($panel instanceof YiiDebugToolbarPanelInterface))


### PR DESCRIPTION
Добавил, проверку для config когда , его тип array. В принципе и до версии 5.4 , часть кода работала "на удачу", когда вместо массива приходят строки => (  isset($config['class']) || $config['class'] = $id ).
