### PR TITLE
Fixed typo in element ID

### DIFF
--- a/yii-debug-toolbar/assets/yii.debugtoolbar.css
+++ b/yii-debug-toolbar/assets/yii.debugtoolbar.css
@@ -39,7 +39,7 @@
 
 }
 
-#yii-debug-toolbar-swither{
+#yii-debug-toolbar-switcher{
     display:block;
     position:fixed;
     z-index:1000000;
@@ -52,7 +52,7 @@
 
 }
 
-#yii-debug-toolbar-swither a{
+#yii-debug-toolbar-switcher a{
     background:transparent url(panel.png) no-repeat scroll center center;
     text-indent:-999999px;
     z-index:100000000;
@@ -62,7 +62,7 @@
     line-height:24px;
     padding:4px 0 0 4px;
 }
-#yii-debug-toolbar-swither a.close{
+#yii-debug-toolbar-switcher a.close{
     background:transparent url(panel-close.png) no-repeat scroll center center;
 }
 

--- a/yii-debug-toolbar/assets/yii.debugtoolbar.js
+++ b/yii-debug-toolbar/assets/yii.debugtoolbar.js
@@ -118,7 +118,7 @@
             if($('#yii-debug-toolbar').is(":visible"))
             {
                 $('#yii-debug-toolbar').hide();
-                $('#yii-debug-toolbar-swither a').removeClass('close');
+                $('#yii-debug-toolbar-switcher a').removeClass('close');
                 $.cookie(COOKIE_NAME, 'hide', {
                     path: '/',
                     expires: 10
@@ -127,7 +127,7 @@
             else
             {
                 $('#yii-debug-toolbar').show();
-                $('#yii-debug-toolbar-swither a').addClass('close');
+                $('#yii-debug-toolbar-switcher a').addClass('close');
                 $.cookie(COOKIE_NAME, null, {
                     path: '/',
                     expires: -1
@@ -136,7 +136,7 @@
         },
 
         registerEventListeners: function() {
-            $('#yii-debug-toolbar-swither').bind('click',$.proxy( this.toggleToolbar, this ));
+            $('#yii-debug-toolbar-switcher').bind('click',$.proxy( this.toggleToolbar, this ));
             $('.yii-debug-toolbar-button').bind('click',$.proxy( this.buttonClicked, this ));
             $('.yii-debug-toolbar-panel-close').bind('click',$.proxy( this.closeButtonClicked, this ));
             $('#yii-debug-toolbar .collapsible').bind('click', function(){ yiiDebugToolbar.toggleSection($(this).attr('rel'), this); });

--- a/yii-debug-toolbar/views/yii_debug_toolbar.php
+++ b/yii-debug-toolbar/views/yii_debug_toolbar.php
@@ -1,4 +1,4 @@
-<div id="yii-debug-toolbar-swither">
+<div id="yii-debug-toolbar-switcher">
     <a href="javascript:;//"><?php echo YiiDebug::t('TOOLBAR')?></a>
 </div>
 <div id="yii-debug-toolbar" style="display:none;">


### PR DESCRIPTION
Was #yii-debug-toolbar-swither, now #yii-debug-toolbar-switcher.
