### PR TITLE
Fix for small JS bug

### DIFF
--- a/yii-debug-toolbar/assets/yii.debugtoolbar.js
+++ b/yii-debug-toolbar/assets/yii.debugtoolbar.js
@@ -140,7 +140,7 @@
             $('.yii-debug-toolbar-button').bind('click',$.proxy( this.buttonClicked, this ));
             $('.yii-debug-toolbar-panel-close').bind('click',$.proxy( this.closeButtonClicked, this ));
             $('#yii-debug-toolbar .collapsible').bind('click', function(){ yiiDebugToolbar.toggleSection($(this).attr('rel'), this); });
-            $('#yii-debug-toolbar .collapsible.collapsed').next().hide();
+            $('#yii-debug-toolbar p.collapsible.collapsed').next().hide();
             $('#yii-debug-toolbar .yii-debug-toolbar-panel-content tbody tr').bind('click', function(){ $(this).toggleClass('selected'); });
         },
 


### PR DESCRIPTION
Fixed a JS bug that was hiding "Level" table header in Logging tab. It still works OK for Views Rendering tab.

**Before:**
![Before](http://ncache.pl/grabs/2012/lvWWi.png)

**After:**
![After](http://ncache.pl/grabs/2012/bjEd4.png)
