### PR TITLE
SQL Panel - always add separator for bind param replace 

### DIFF
--- a/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
+++ b/yii-debug-toolbar/panels/YiiDebugToolbarPanelSql.php
@@ -366,8 +366,8 @@ class YiiDebugToolbarPanelSql extends YiiDebugToolbarPanel
 
             if ($matchResult) {
                 foreach ($paramsMatched as $paramsMatch)
-	                if (isset($paramsMatch['key'], $paramsMatch['value']))
-                        $binds[trim($paramsMatch['key'])] = trim($paramsMatch['value']);
+	                if (isset($paramsMatch['key'], $paramsMatch['value']))                        
+                        $binds[':' . trim($paramsMatch['key'],': ')] = trim($paramsMatch['value']);
             }
 
 


### PR DESCRIPTION
Always add symbol ":" for placeholders and replace in sql text by strtr.

Так как при bindParam(), bindValue() не обязательно указывать в названии параметра двоеточие, то код подстановки значений иногда очень сильно  "портит" SQL запрос.

К примеру было:
BEGIN DBMS_SESSION.set_identifier (:ident); END;. Bound with ident='ID=20703'

А стало:
BEGIN DBMS_SESSION.set_'ID=20703'ifier (:'ID=20703'); END;
