### PR TITLE
Support headers with empty value

### DIFF
--- a/yii-debug-toolbar/YiiDebugToolbarRoute.php
+++ b/yii-debug-toolbar/YiiDebugToolbarRoute.php
@@ -192,7 +192,8 @@ class YiiDebugToolbarRoute extends CLogRoute
       $contentType = '';
 
       foreach (headers_list() as $header) {
-        list($key, $value) = explode(': ', $header);
+        list($key, $value) = explode(':', $header);
+        $value = ltrim($value, ' ');
         if (strtolower($key) === 'content-type') {
           // Split encoding if exists
           $contentType = explode(";", strtolower($value));


### PR DESCRIPTION
Поддержка HTTP заголовков, у которых отсутствует значение.
Поймал такую ситуацию, когда делал не правильный редирект.
