### PR TITLE
Fix debug backtrace signature change

### DIFF
--- a/yii-debug-toolbar/components/YiiDebugViewRenderer.php
+++ b/yii-debug-toolbar/components/YiiDebugViewRenderer.php
@@ -89,7 +89,13 @@ class YiiDebugViewRenderer extends ProxyComponent
         // - DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS
         $debugBacktrace = debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT );
       }
-      else
+      elseif (version_compare(PHP_VERSION, '5.2.5', '>='))
+      {
+        // signature is:
+        // array debug_backtrace ([ bool $provide_object = TRUE ] )
+        $debugBacktrace = debug_backtrace( true );
+      }
+      else /* version < 5.2.5 */
       {
         // signature is:
         // array debug_backtrace ( )

--- a/yii-debug-toolbar/components/YiiDebugViewRenderer.php
+++ b/yii-debug-toolbar/components/YiiDebugViewRenderer.php
@@ -57,7 +57,46 @@ class YiiDebugViewRenderer extends ProxyComponent
 
     protected function getDebugBacktrace()
     {
-      debug_backtrace(true);
+      // @see "http://www.php.net/manual/en/function.debug-backtrace.php"
+      // 
+      // debug_backtrace Changelog
+      // 
+      // Version  Description
+      // 5.4.0    Added the optional parameter limit.
+      // 5.3.6    The parameter provide_object changed to options and
+      //          additional option DEBUG_BACKTRACE_IGNORE_ARGS is added.
+      // 5.2.5    Added the optional parameter provide_object.
+      // 5.1.1    Added the current object as a possible return element.
+      if (PHP_VERSION_ID >= 50400)
+      {
+        // signature is:
+        // array debug_backtrace ([ int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT [, int $limit = 0 ]] )
+        // 
+        // possible values for $options:
+        // - DEBUG_BACKTRACE_PROVIDE_OBJECT
+        // - DEBUG_BACKTRACE_IGNORE_ARGS
+        // - DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS
+        $debugBacktrace = debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT );
+      }
+      elseif (PHP_VERSION_ID >= 50306)
+      {
+        // signature is:
+        // array debug_backtrace ([ int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT ] )
+        // 
+        // possible values for $options:
+        // - DEBUG_BACKTRACE_PROVIDE_OBJECT
+        // - DEBUG_BACKTRACE_IGNORE_ARGS
+        // - DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS
+        $debugBacktrace = debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT );
+      }
+      else
+      {
+        // signature is:
+        // array debug_backtrace ( )
+        $debugBacktrace = debug_backtrace();
+      }
+      
+      return $debugBacktrace;
     }
     
     protected function collectDebugInfo($context, $sourceFile, $data)

--- a/yii-debug-toolbar/components/YiiDebugViewRenderer.php
+++ b/yii-debug-toolbar/components/YiiDebugViewRenderer.php
@@ -55,12 +55,17 @@ class YiiDebugViewRenderer extends ProxyComponent
         }
     }
 
+    protected function getDebugBacktrace()
+    {
+      debug_backtrace(true);
+    }
+    
     protected function collectDebugInfo($context, $sourceFile, $data)
     {
         if($context instanceof YiiDebugToolbar || false !== ($context instanceof YiiDebugToolbarPanel))
             return;
 
-        $backTrace = debug_backtrace(true);
+        $backTrace = $this->getDebugBacktrace();
         $backTraceItem = null;
 
         while($backTraceItem = array_shift($backTrace))

--- a/yii-debug-toolbar/components/YiiDebugViewRenderer.php
+++ b/yii-debug-toolbar/components/YiiDebugViewRenderer.php
@@ -54,7 +54,7 @@ class YiiDebugViewRenderer extends ProxyComponent
             return $this->instance->generateViewFile($sourceFile, $viewFile);
         }
     }
-
+    
     protected function getDebugBacktrace()
     {
       // @see "http://www.php.net/manual/en/function.debug-backtrace.php"
@@ -67,7 +67,7 @@ class YiiDebugViewRenderer extends ProxyComponent
       //          additional option DEBUG_BACKTRACE_IGNORE_ARGS is added.
       // 5.2.5    Added the optional parameter provide_object.
       // 5.1.1    Added the current object as a possible return element.
-      if (PHP_VERSION_ID >= 50400)
+      if (version_compare(PHP_VERSION, '5.4.0', '>='))
       {
         // signature is:
         // array debug_backtrace ([ int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT [, int $limit = 0 ]] )
@@ -78,7 +78,7 @@ class YiiDebugViewRenderer extends ProxyComponent
         // - DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS
         $debugBacktrace = debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT );
       }
-      elseif (PHP_VERSION_ID >= 50306)
+      elseif (version_compare(PHP_VERSION, '5.3.6', '>='))
       {
         // signature is:
         // array debug_backtrace ([ int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT ] )


### PR DESCRIPTION
This fix makes it possible to use the debug toolbar with PHP < v5.2.5
