### PR TITLE
removed wrong type from composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "malyshev/yii-debug-toolbar",
     "description": "A configurable set of panels that display various debug information about the current request/response.",
     "keywords": ["yii", "debug", "extension"],
-    "type": "yii-extension",
     "license": "BSD-3-Clause",
     "authors": [
         {


### PR DESCRIPTION
`type` field in composer for this project myst be `library` or omitted
Read more at http://getcomposer.org/doc/04-schema.md#type
