### PR TITLE
Disable and hide yii-debug-toolbar when jQuery is not defined.

### DIFF
--- a/yii-debug-toolbar/views/yii_debug_toolbar.php
+++ b/yii-debug-toolbar/views/yii_debug_toolbar.php
@@ -1,4 +1,4 @@
-<div id="yii-debug-toolbar-switcher">
+<div id="yii-debug-toolbar-switcher" style="display:none;">
     <a href="javascript:;//"><?php echo YiiDebug::t('TOOLBAR')?></a>
 </div>
 <div id="yii-debug-toolbar" style="display:none;">
@@ -51,5 +51,8 @@
 </div>
 
 <script type="text/javascript">
-(function($) {$(function(){yiiDebugToolbar.init()})}(jQuery));
+if(window.jQuery){
+    $('#yii-debug-toolbar-switcher').show();
+    (function($) {$(function(){yiiDebugToolbar.init()})}(jQuery));
+}
 </script>


### PR DESCRIPTION
Console error which halts the javascript on the whole page.
Uncaught ReferenceError: jQuery is not defined.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/malyshev/yii-debug-toolbar/87)

<!-- Reviewable:end -->
