### PR TITLE
fix display of labels when you are using twitter bootstrap's css

### DIFF
--- a/yii-debug-toolbar/assets/yii.debugtoolbar.css
+++ b/yii-debug-toolbar/assets/yii.debugtoolbar.css
@@ -231,7 +231,9 @@ line-height:50px;
     text-decoration:none;
 }
 
-
+#yii-debug-toolbar label {
+    display: inline;
+}
 
 /* tabs */
 


### PR DESCRIPTION
very minor fix that prevents label from being rendered as block element if you have twitter bootstrap's css running
