### PR TITLE
Update YiiDebugToolbarRoute.php

### DIFF
--- a/YiiDebugToolbarRoute.php
+++ b/YiiDebugToolbarRoute.php
@@ -190,7 +190,9 @@ class YiiDebugToolbarRoute extends CLogRoute
 
     protected function processLogs($logs)
     {
-        $this->getToolbarWidget()->run();
+        // Check content types again, as it may have not been defined at the beiggining of the processing (as in excel download with GZIP)
+        if ($this->checkContentTypeWhitelist()) 
+        	$this->getToolbarWidget()->run();
     }
 
     private function checkContentTypeWhitelist()


### PR DESCRIPTION
Fix: Re Check content types before echoing the output, as the content-type may have not been defined at the beiggining of the processing (as in excel download with GZIP)
