### PR TITLE
yii debug cannot work when ues in remote

### DIFF
--- a/YiiDebug.php
+++ b/YiiDebug.php
@@ -35,7 +35,7 @@ class YiiDebug extends CComponent
             }
             return;
         } else if (empty($_SERVER['SERVER_ADDR']) || empty($_SERVER['REMOTE_ADDR']) || $_SERVER['SERVER_ADDR'] !== $_SERVER['REMOTE_ADDR']) {
-            return;
+            //return;
         }
 
         $backTrace = debug_backtrace();


### PR DESCRIPTION
the logic of check `SERVER_ADDR=REMOTE_ADDR` will lead to lots of value cannot see  when you server and your browser are not in the same machine so i commnet the `return` statement
