### PR TITLE
Rendering Views With Null Data Throws 500 Not Countable

### DIFF
--- a/views/panels/views.php
+++ b/views/panels/views.php
@@ -97,7 +97,7 @@ $index = 1;
                                     <td><?php echo $this->getFilePath($item['sourceFile']) ?></td>
                                 </tr>
                         
-                                <?php if(!(1===count($item['data']) && isset($item['data']['content']))): ?>
+                                <?php if(isset($item['data']) && !(1===count($item['data']) && isset($item['data']['content']))): ?>
                                 <tr>
                                     <th>View data</th>
                                     <td>


### PR DESCRIPTION
I get the following 500 error when using a `renderPartial()` with no `$data` parameter: PHP warning: count(): Parameter must be an array or an object that implements Countable.

Stacktrace points to: /var/www/html/protected/extensions/yii-debug-toolbar/views/panels/views.php line 100.

The signature for `renderPartial($view, $data=null)` specifies `$data` as optional. The "Views Rendering" panel doesn't account for this and attempts to call `count()` on `null` resulting in said 500 error.